### PR TITLE
Add node version for Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "homepage": "https://github.com/howiesommerfeld/my-tech-journey#readme",
   "dependencies": {
     "express": "^4.17.1"
+  },
+  "engines": {
+    "node": "10.16.3"
   }
 }


### PR DESCRIPTION
Ran into an error when visiting the site after initially deploying to Heroku, so specifying the Node version in package.json seems to have fixed that. 